### PR TITLE
Fix typo in faq.md

### DIFF
--- a/program-guide/faq.md
+++ b/program-guide/faq.md
@@ -22,7 +22,7 @@ Here are some frequently asked questions about EPF program. Please also watch th
     - Funding options for both crypto and fiat will be available.
 - **Will there be an interview process?**
     - Yes. After reviewing applications, select applicants will be scheduled for an interview. 
-- **How many applicants will be accepted in the first cohort?**
+- **How many applicants will be accepted in this cohort?**
     - The exact number depends on number of applications, budget, and capacity of mentors. We are targeting between 20 and 30 participants.
 - **Can I still participate even if I am not selected in this cohort?**
     - Yes. Being selected into the program is really just the group that we'll be working directly with to provide funding. The program is going to happen in the open, meaning that anyone who wants to participate can be a part of the program with the same resources (aside from funding) as those that are "selected". Those that participate in a permissionless fashion may be eligible for a retroactive stipend after displaying aptitude and dedication.


### PR DESCRIPTION
Changed the phrase 'the first cohort' to 'this cohort' in a question in FAQ for general applicability.