### PR TITLE
docs: fix typo in project description

### DIFF
--- a/projects/Prysm_libP2P_Implementation.md
+++ b/projects/Prysm_libP2P_Implementation.md
@@ -18,7 +18,7 @@ The libP2P protocol has several components for example: Noise, multiplexer, pubs
 
 ## Specification
 
-We'll will following the [CL specs](https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/p2p-interface.md) for the development of this new package.
+We will following the [CL specs](https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/p2p-interface.md) for the development of this new package.
 
 Major components used in Prysm:
 * `devp2p/discv5` (outside the project scope)


### PR DESCRIPTION
fixed typo in the project description where "We'll will following the [CL specs]" was used.
the correct phrasing is "We will follow the [CL specs] for the development of this new package."