### PR TITLE
ci: bump upload-artifact to v4

### DIFF
--- a/.github/workflows/table_linter.yml
+++ b/.github/workflows/table_linter.yml
@@ -53,7 +53,7 @@ jobs:
 
       # Upload MegaLinter artifacts
       - name: Archive production artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ success() }} || ${{ failure() }}
         with:
           name: MegaLinter reports


### PR DESCRIPTION
Bumps actions/upload-artifact to v4 for improved performance and future compatibility. More info: https://github.com/actions/upload-artifact/releases